### PR TITLE
Added options to specify a email address when creating an fxa account.

### DIFF
--- a/pytest_fxa/plugin.py
+++ b/pytest_fxa/plugin.py
@@ -17,6 +17,16 @@ here = os.path.dirname(__file__)
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
+def pytest_addoption(parser):
+    group = parser.getgroup('fxa')
+    group.addoption(
+        '--fxa-email',
+        action='store',
+        dest='fxa_email',
+        help='Email used to create fxa account.'
+    )
+
+
 @pytest.fixture(scope='session')
 def fxa_client(fxa_urls):
     return Client(fxa_urls['authentication'])
@@ -24,13 +34,18 @@ def fxa_client(fxa_urls):
 
 @pytest.fixture(scope='session')
 def fxa_urls(pytestconfig):
-    return ENVIRONMENT_URLS[os.getenv('FXA_ENV', 'stage')]
+    return ENVIRONMENT_URLS[os.getenv('FXA_ENV', 'stable')]
+
+
+@pytest.fixture(scope='session')
+def fxa_email(request):
+    return request.config.getoption('fxa_email') or os.getenv('FXA_EMAIL')
 
 
 @pytest.fixture
-def fxa_account(fxa_client):
+def fxa_account(fxa_client, fxa_email):
     logger = logging.getLogger()
-    account = TestEmailAccount()
+    account = TestEmailAccount(email=fxa_email)
     password = ''.join([random.choice(string.ascii_letters) for i in range(8)])
     FxAccount = collections.namedtuple('FxAccount', 'email password')
     fxa_account = FxAccount(email=account.email, password=password)

--- a/pytest_fxa/plugin.py
+++ b/pytest_fxa/plugin.py
@@ -37,7 +37,7 @@ def fxa_urls(pytestconfig):
     return ENVIRONMENT_URLS[os.getenv('FXA_ENV', 'stage')]
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def fxa_email(request):
     return request.config.getoption('fxa_email') or os.getenv('FXA_EMAIL')
 

--- a/pytest_fxa/plugin.py
+++ b/pytest_fxa/plugin.py
@@ -34,7 +34,7 @@ def fxa_client(fxa_urls):
 
 @pytest.fixture(scope='session')
 def fxa_urls(pytestconfig):
-    return ENVIRONMENT_URLS[os.getenv('FXA_ENV', 'stable')]
+    return ENVIRONMENT_URLS[os.getenv('FXA_ENV', 'stage')]
 
 
 @pytest.fixture(scope='session')

--- a/pytest_fxa/plugin.py
+++ b/pytest_fxa/plugin.py
@@ -38,8 +38,8 @@ def fxa_urls(pytestconfig):
 
 
 @pytest.fixture
-def fxa_email(request):
-    return request.config.getoption('fxa_email') or os.getenv('FXA_EMAIL')
+def fxa_email(pytestconfig):
+    return pytestconfig.getoption('fxa_email') or os.getenv('FXA_EMAIL')
 
 
 @pytest.fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,6 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import random
+import string
+
+import pytest
+
+
+@pytest.fixture
+def random_email():
+    test_string = ''.join(random.choice(
+        string.ascii_letters + string.digits) for _ in range(8))
+    return '{}@restmail.net'.format(test_string)
+
 
 def test_login(testdir):
     testdir.makepyfile("""
@@ -35,24 +47,28 @@ def test_destroyed(testdir):
     assert 'ClientError: Unknown account' in result.stdout.str()
 
 
-def test_commandline_email_option(testdir):
+def test_commandline_email_option(testdir, monkeypatch, random_email):
+    monkeypatch.setenv('TEST_EMAIL', '{}'.format(random_email))
     testdir.makepyfile("""
-        import pytest
+        import os
 
+        import pytest
         def test_account(fxa_account):
-            assert 'testemail@restmail.net' in fxa_account.email
+            assert os.getenv('TEST_EMAIL') == fxa_account.email
     """)
-    result = testdir.runpytest('--fxa-email', 'testemail@restmail.net')
+    result = testdir.runpytest('--fxa-email', random_email)
     result.assert_outcomes(passed=1)
 
 
-def test_fxa_email_env_variable(testdir, monkeypatch):
-    monkeypatch.setenv('FXA_EMAIL', 'testemail@restmail.net')
+def test_fxa_email_env_variable(testdir, monkeypatch, random_email):
+    monkeypatch.setenv('FXA_EMAIL', '{}'.format(random_email))
     testdir.makepyfile("""
+        import os
+
         import pytest
 
         def test_account(fxa_account):
-            assert 'testemail@restmail.net' in fxa_account.email
+            assert os.getenv('FXA_EMAIL') == fxa_account.email
     """)
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -47,16 +47,13 @@ def test_destroyed(testdir):
     assert 'ClientError: Unknown account' in result.stdout.str()
 
 
-def test_commandline_email_option(testdir, monkeypatch, random_email):
-    monkeypatch.setenv('TEST_EMAIL', '{}'.format(random_email))
+def test_commandline_email_option(testdir, random_email):
     testdir.makepyfile("""
-        import os
-
         import pytest
 
         def test_account(fxa_account):
-            assert os.getenv('TEST_EMAIL') == fxa_account.email
-    """)
+            assert '{}' == fxa_account.email
+    """.format(random_email))
     result = testdir.runpytest('--fxa-email', random_email)
     result.assert_outcomes(passed=1)
 
@@ -69,7 +66,7 @@ def test_fxa_email_env_variable(testdir, monkeypatch, random_email):
         import pytest
 
         def test_account(fxa_account):
-            assert os.getenv('FXA_EMAIL') == fxa_account.email
-    """)
+            assert '{}' == fxa_account.email
+    """.format(random_email))
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -38,7 +38,21 @@ def test_destroyed(testdir):
 def test_commandline_email_option(testdir):
     testdir.makepyfile("""
         import pytest
-        def test_pass(fxa_account): pass
+
+        def test_account(fxa_account): 
+            assert 'testemail@restmail.net' in fxa_account.email
     """)
     result = testdir.runpytest('--fxa-email', 'testemail@restmail.net')
     result.assert_outcomes(passed=1)
+
+def test_fxa_email_env_variable(testdir, monkeypatch):
+    monkeypatch.setenv('FXA_EMAIL', 'testemail@restmail.net')
+    testdir.makepyfile("""
+        import pytest
+
+        def test_account(fxa_account):
+            assert 'testemail@restmail.net' in fxa_account.email
+    """)
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -39,11 +39,12 @@ def test_commandline_email_option(testdir):
     testdir.makepyfile("""
         import pytest
 
-        def test_account(fxa_account): 
+        def test_account(fxa_account):
             assert 'testemail@restmail.net' in fxa_account.email
     """)
     result = testdir.runpytest('--fxa-email', 'testemail@restmail.net')
     result.assert_outcomes(passed=1)
+
 
 def test_fxa_email_env_variable(testdir, monkeypatch):
     monkeypatch.setenv('FXA_EMAIL', 'testemail@restmail.net')
@@ -55,4 +56,3 @@ def test_fxa_email_env_variable(testdir, monkeypatch):
     """)
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
-

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -53,6 +53,7 @@ def test_commandline_email_option(testdir, monkeypatch, random_email):
         import os
 
         import pytest
+
         def test_account(fxa_account):
             assert os.getenv('TEST_EMAIL') == fxa_account.email
     """)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -33,3 +33,12 @@ def test_destroyed(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(error=1, passed=1)
     assert 'ClientError: Unknown account' in result.stdout.str()
+
+
+def test_commandline_email_option(testdir):
+    testdir.makepyfile("""
+        import pytest
+        def test_pass(fxa_account): pass
+    """)
+    result = testdir.runpytest('--fxa-email', 'testemail@restmail.net')
+    result.assert_outcomes(passed=1)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -61,8 +61,6 @@ def test_commandline_email_option(testdir, random_email):
 def test_fxa_email_env_variable(testdir, monkeypatch, random_email):
     monkeypatch.setenv('FXA_EMAIL', '{}'.format(random_email))
     testdir.makepyfile("""
-        import os
-
         import pytest
 
         def test_account(fxa_account):


### PR DESCRIPTION
This should allow the user to pass a command line option ```--fxa-email``` or override the fixture ```fxa_email``` to create an fxa restmail account with a specific email.

Fixes #2 