### PR TITLE
Allow the Firefox Accounts environment to be parameterised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 .eggs
 .pytest_cache
 .tox

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,28 @@ Specifying an environment
 
 By default all accounts will be created on the 'stage' environment. You can set
 the ``FXA_ENV`` environment variable to target 'production' or 'stable'.
-Alternatively, you can override the ``fxa_urls`` fixture to specify the URL for
-you environment:
+
+If you need to override the environment for a subset of tests, or run tests against multiple environments, you can do this using parameterisation:
+
+.. code-block:: python
+
+  @pytest.mark.parametrize('fxa_urls', ['production'], indirect=True)
+  def test_production(fxa_account):
+      selenium.get('https://example.com/')
+      selenium.find_element(By.ID, 'email').send_keys(fxa_account.email)
+      selenium.find_element(By.ID, 'password').send_keys(fxa_account.password)
+      selenium.find_element(By.ID, 'login').click()
+
+
+  @pytest.mark.parametrize('fxa_urls', ['stage'], indirect=True)
+  def test_stage(fxa_account):
+      selenium.get('https://elpmaxe.com/')
+      selenium.find_element(By.ID, 'email').send_keys(fxa_account.email)
+      selenium.find_element(By.ID, 'password').send_keys(fxa_account.password)
+      selenium.find_element(By.ID, 'login').click()
+
+Alternatively, you can override the ``fxa_urls`` fixture for full control of
+the URLs for your environment:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -64,11 +64,11 @@ Specifying an environment
 By default all accounts will be created on the 'stage' environment. You can set
 the ``FXA_ENV`` environment variable to target 'production' or 'stable'.
 
-If you need to override the environment for a subset of tests, or run tests against multiple environments, you can do this using parameterisation:
+If you need to override the environment for a subset of tests, or run tests against multiple environments, you can use the ``fxa_env`` marker:
 
 .. code-block:: python
 
-  @pytest.mark.parametrize('fxa_urls', ['production'], indirect=True)
+  @pytest.mark.fxa_env('production')
   def test_production(fxa_account):
       selenium.get('https://example.com/')
       selenium.find_element(By.ID, 'email').send_keys(fxa_account.email)
@@ -76,7 +76,7 @@ If you need to override the environment for a subset of tests, or run tests agai
       selenium.find_element(By.ID, 'login').click()
 
 
-  @pytest.mark.parametrize('fxa_urls', ['stage'], indirect=True)
+  @pytest.mark.fxa_env('stage', 'stable')
   def test_stage(fxa_account):
       selenium.get('https://elpmaxe.com/')
       selenium.find_element(By.ID, 'email').send_keys(fxa_account.email)

--- a/pytest_fxa/plugin.py
+++ b/pytest_fxa/plugin.py
@@ -28,6 +28,26 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'fxa_env(name,): mark tests to run against named Firefox Accounts '
+        'environment(s): ' + ', '.join(ENVIRONMENT_URLS.keys()))
+
+
+def pytest_generate_tests(metafunc):
+    if 'fxa_urls' not in metafunc.fixturenames:
+        return
+
+    envs = set([
+        env_name
+        for marker in metafunc.definition.iter_markers('fxa_env')
+        for env_name in marker.args])
+
+    if envs:
+        metafunc.parametrize('fxa_urls', envs, indirect=True)
+
+
 @pytest.fixture
 def fxa_client(fxa_urls):
     return Client(fxa_urls['authentication'])

--- a/pytest_fxa/plugin.py
+++ b/pytest_fxa/plugin.py
@@ -28,14 +28,15 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def fxa_client(fxa_urls):
     return Client(fxa_urls['authentication'])
 
 
-@pytest.fixture(scope='session')
-def fxa_urls(pytestconfig):
-    return ENVIRONMENT_URLS[os.getenv('FXA_ENV', 'stage')]
+@pytest.fixture
+def fxa_urls(request):
+    env = getattr(request, 'param', os.getenv('FXA_ENV', 'stage'))
+    return ENVIRONMENT_URLS[env]
 
 
 @pytest.fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -105,15 +105,15 @@ def test_fxa_env_env_variable(monkeypatch, testdir):
     result.assert_outcomes(passed=1)
 
 
-def test_parametrize_can_override_env(monkeypatch, testdir):
-    env, param = ['stable', 'stage']
+def test_fxa_env_marker(monkeypatch, testdir):
+    env, marker = ['stable', 'stage']
     monkeypatch.setenv('FXA_ENV', env)
     testdir.makepyfile("""
         import pytest
 
-        @pytest.mark.parametrize('fxa_urls', ['{0}'], indirect=True)
+        @pytest.mark.fxa_env('{0}')
         def test_account(fxa_urls):
             assert '{0}' in fxa_urls['authentication']
-    """.format(param))
+    """.format(marker))
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -117,3 +117,26 @@ def test_fxa_env_marker(monkeypatch, testdir):
     """.format(marker))
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_fxa_env_marker_multi(monkeypatch, testdir):
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.fxa_env('stable', 'stage')
+        def test_account(fxa_urls): pass
+    """)
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)
+
+
+def test_fxa_env_marker_empty(monkeypatch, testdir):
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.fxa_env()
+        def test_account(fxa_urls):
+            assert 'stage' in fxa_urls['authentication']
+    """)
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -90,3 +90,30 @@ def test_no_email_given(testdir):
     """)
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_fxa_env_env_variable(monkeypatch, testdir):
+    env = 'stable'
+    monkeypatch.setenv('FXA_ENV', env)
+    testdir.makepyfile("""
+        import pytest
+
+        def test_account(fxa_urls):
+            assert '{0}' in fxa_urls['authentication']
+    """.format(env))
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_parametrize_can_override_env(monkeypatch, testdir):
+    env, param = ['stable', 'stage']
+    monkeypatch.setenv('FXA_ENV', env)
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.parametrize('fxa_urls', ['{0}'], indirect=True)
+        def test_account(fxa_urls):
+            assert '{0}' in fxa_urls['authentication']
+    """.format(param))
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
This patch allows anything that accepts a parameterised mark to override the environment. This means that if you have a single test that requires the production environment, you can just add the appropriate mark to that test. It also allows tests to be executed against multiple environments by providing additional parameters.