### PR TITLE
Use a similar method to generating random emails for tests

### DIFF
--- a/pytest_fxa/plugin.py
+++ b/pytest_fxa/plugin.py
@@ -94,7 +94,6 @@ def fxa_account(fxa_client, fxa_email):
     try:
         session = fxa_client.create_account(fxa_account.email, fxa_account.password)
         logger.info("Created: {}".format(fxa_account))
-        account.fetch()
         message = account.wait_for_email(
             lambda m: "x-verify-code" in m["headers"]
             and session.uid == m["headers"]["x-uid"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import random
-import string
 
 import pytest
 from fxa.core import Session
@@ -13,10 +12,7 @@ from pytest_fxa import plugin
 
 @pytest.fixture
 def random_email():
-    test_string = "".join(
-        random.choice(string.ascii_letters + string.digits) for _ in range(8)
-    )
-    return "{}@restmail.net".format(test_string)
+    return "pytester-{:0x}@restmail.net".format(random.getrandbits(10 * 4))
 
 
 def test_login(testdir):


### PR DESCRIPTION
Instead of concatenating a string of letters and digits when testing the command line and environment variable email address overrides, use a similar method to how the plugin would generate an email address. This appears to fix recent test failures where verification emails were not being recieved.

I also removed an uneccessary call to `account.fetch` as this is called within `account.wait_for_email`.